### PR TITLE
Bootstrap eRegs for CFPB

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 regulations-core/
 regulations-parser/
 regulations-site/
+fr-notices/
 .DS_Store
 .DS_Store?
 ._*

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,11 @@
-.DS_Store
 .vagrant
 regulations-core/
 regulations-parser/
 regulations-site/
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+*~
+*.swp

--- a/README.md
+++ b/README.md
@@ -1,20 +1,109 @@
-### Native Install
+# regulations-bootstrap
 
-1. First, ensure you have virtualenv-wrapper installed: (`pip install virtualenv-wrapper`)
-2. Run `./regs_bootstrap.sh` to clone directories and install dependencies
+[eRegulations](http://cfpb.github.io/eRegulations) is a web-based tool that makes regulations easier to find, read and understand with features such as inline official interpretations, highlighted defined terms, and a revision comparison view.
+
+eRegs is made up of three core components:
+
+* [regulations-parser](https://github.com/cfpb/regulations-parser): Parse regulations
+* [regulations-core](https://github.com/cfpb/regulations-core): Regulations API
+* [regulations-site](https://github.com/cfpb/regulations-site): Display the regulations
+
+This repository contains scripts that boostrap a coherent eRegulations working envionrment, either locally or in a [Vagrant](https://www.vagrantup.com/) virtual machine.
+
+## Bootstrap Locally
+
+To bootstrap a local (i.e. not virtualized) eRegs environment, you'll
+need to install Python's virtualenv and virtualenvwrapper. 
+
+### Requirements
+
+Install [virtualenv](https://virtualenv.pypa.io/en/latest/):
+
+```shell
+pip install virtualenv
+```
+
+Then install and configure 
+[virtualenvwrapper](https://virtualenvwrapper.readthedocs.org/en/latest/). 
+More information on how virtualenvwrapper works and how you may wish to 
+set it up in your shell can be found in the 
+[virtualenvwrapper documentation](https://virtualenvwrapper.readthedocs.org/en/latest/install.html).
+
+```shell
+pip install virtualenvwrapper
+export WORKON_HOME=~/envs
+mkdir -p $WORKON_HOME
+source `which virtualenvwrapper.sh`
+```
+
+### Bootstrapping
+
+Once you have these requirements installed you can run the
+`regs_bootstrap.sh`:
+
+```shell
+./regs_bootstrap.sh
+```
+
+This will clone all of the eRegs repositories, make seperate virtualenvs 
+for them, and setup their dependencies.
+
+## Bootstrap with Vagrant
+
+To bootstrap eRegs in a [Vagrant](https://www.vagrantup.com/) virtual 
+machine, you'll need to install Vagrant locally. Everything else should 
+be taken care of by this repository's `Vagrantfile`.
+
+### Requirements
+
+Install [Vagrant](https://www.vagrantup.com/). On Mac OS X, this can be
+done with [Homebrew](http://brew.sh):
+
+```shell
+brew install vagrant
+```
+
+### Bootstrapping
+
+The eRegs bootstrapping process will be performed as part of the Vagrant
+provisioning process. All one needs to do is provision the Vagrant
+virtual machine. 
+
+```shell
+vagrant up
+```
+
+Once the virtual machine is running, you should be able to access
+regulations-core at [http://localhost:8000](http://localhost:8000) and 
+regulations-site at [http://localhost:8001](http://localhost:8001).
+
+You can also connect to the virtual machine via SSH.
+
+```shell
+vagrant ssh
+```
+
+## Using
+
+Before you can use regulations-site to browse any regulations, you'll
+need to parse some with regulations-parser. To do this you'll need to
+SSH into the virtual machine and run the parser. 
+
+To parse the [CFPB's Regulation E](http://www.consumerfinance.gov/eregulations/1005), 
+for example, you would do the following:
+
+```shell
+workon reg-parser
+cd /vagrant/regulations-parser
+./build_from.py ../fr-notices/annual/CFR-2012-title12-vol8-part1026.xml 12 2011-31715 15 1601
+```
+
+Once completed, the JSON for this regulation can be browsed in
+regulations-core at [http://localhost:8000](http://localhost:8000) and
+can be viewed in regulations-site at [http://localhost:8001](http://localhost:8001).
+
+Because all of the components are stored in your Vagrant project
+directory you can use your favorite IDE or editor to work on them and
+see your changes running in the virtual machine.
 
 
-### Vagrant Install
-1. `brew cask install vagrant`
-2. `vagrant up` to create and provision the VM
-3. `vagrant ssh` to connect to the running VM
-4. `cp /vagrant/regs_bootstrap.sh regs_bootstrap.sh && ./regs_bootstrap.sh` to clone directories and install dependencies
-5. Continue from step 3 above.
-
-
-### Start Server and Download XML files to start playing
-1. From regulations-core/, start a server with `./bin/django runserver`
-2. From regulations-site/, start a server with `./bin/django runserver 8001`
-3. Download an XML file of a full regulation from [http://www.gpo.gov/](http://www.gpo.gov/), for example, [Title 12](http://www.gpo.gov/fdsys/pkg/CFR-2010-title12-vol1/content-detail.html) and put that in `regulations-parser/`
-4. Run the parser against a regulation by running `python build_from.py CFR-2012-title12-vol8-part1004.xml 12 2011-18676 15 1693`
-5. The results will write to the API, and can be viewed at [http://localhost:8001](http://localhost:8001)

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,9 +1,22 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
 
 Vagrant.configure(2) do |config|
+
   config.vm.box = "ubuntu/trusty64"
-  config.vm.provision :shell, path: "bootstrap.sh"
-  config.vm.network :forwarded_port, host: 8080, guest: 8001
+
+  # Run the bootstrap script
+  config.vm.provision :shell, path: "bootstrap.sh", run: "once"
+  config.vm.provision :shell, path: "startup.sh", run: "always", privileged: false
+
+  # Forward the regulations-core for API browsing
+  config.vm.network :forwarded_port, host: 8000, guest: 8000
+
+  # Forward the regulations-site
+  config.vm.network :forwarded_port, host: 8001, guest: 8001
+
   config.vm.provider "virtualbox" do |vb|
     vb.memory = 1024
   end
 end
+

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -6,7 +6,6 @@ apt-get install git -y
 apt-get install python-dev -y
 apt-get install python-pip -y
 apt-get install libxml2-dev libxslt1-dev zlib1g-dev -y
-apt-get install pypy-dev -y 
 
 # Install Python dependencies
 pip install virtualenv

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,14 +1,18 @@
 #!/usr/bin/env bash
 
+# Install system dependencies
 apt-get update
 apt-get install git -y
 apt-get install python-dev -y
 apt-get install python-pip -y
 apt-get install libxml2-dev libxslt1-dev zlib1g-dev -y
+apt-get install pypy-dev -y 
 
+# Install Python dependencies
 pip install virtualenv
 pip install virtualenvwrapper
 
+# Setup eRegs environment
 sudo su vagrant <<'EOF'
 mkdir ~/.virtualenvs
 echo "export WORKON_HOME=~/.virtualenvs" >> ~/.bashrc
@@ -16,4 +20,5 @@ echo "export VIRTUALENVWRAPPER_VIRTUALENV=/usr/local/bin/virtualenv" >> ~/.bashr
 echo "source /usr/local/bin/virtualenvwrapper.sh" >> ~/.bashrc
 source ~/.bashrc
 source /usr/local/bin/virtualenvwrapper.sh
+cd /vagrant && ./regs_bootstrap.sh
 EOF

--- a/regs_bootstrap.sh
+++ b/regs_bootstrap.sh
@@ -1,22 +1,33 @@
 #!/usr/bin/env bash
+
+# Clone the relevent repos
 git clone https://github.com/cfpb/regulations-parser
 git clone https://github.com/cfpb/regulations-core
 git clone https://github.com/cfpb/regulations-site
 git clone https://github.com/cfpb/fr-notices.git
+
+# Make virtualenvs for each component.
+source `which virtualenvwrapper.sh`
 mkvirtualenv reg-parser
 mkvirtualenv reg-core
 mkvirtualenv reg-site
+
+# Setup the parser
 cd regulations-parser
 workon reg-parser
 pip install -r requirements.txt
 pip install -r requirements_test.txt
 echo 'API_BASE = "http://localhost:8000/"' >> local_settings.py
+
+# Setup the API
 cd ../regulations-core
 workon reg-core
 pip install zc.buildout
 buildout
 ./bin/django syncdb
 ./bin/django migrate
+
+# Setup the front-end site
 cd ../regulations-site
 workon reg-site
 pip install zc.buildout
@@ -24,3 +35,4 @@ buildout
 cp regulations/settings/base.py regulations/settings/local_settings.py
 sed -i -e 's|^DEBUG = False|DEBUG = True|' regulations/settings/local_settings.py
 sed -i -e "s|API_BASE = ''|API_BASE = 'http://localhost:8000/'|" regulations/settings/local_settings.py
+

--- a/regs_bootstrap.sh
+++ b/regs_bootstrap.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
-source /usr/local/bin/virtualenvwrapper.sh
-git clone https://github.com/18f/regulations-parser
-git clone https://github.com/18f/regulations-core
-git clone https://github.com/18f/regulations-site
+git clone https://github.com/cfpb/regulations-parser
+git clone https://github.com/cfpb/regulations-core
+git clone https://github.com/cfpb/regulations-site
+git clone https://github.com/cfpb/fr-notices.git
 mkvirtualenv reg-parser
 mkvirtualenv reg-core
 mkvirtualenv reg-site

--- a/startup.sh
+++ b/startup.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+# Ensure we have virtualenvwrapper sourced so we can `workon`
+source `which virtualenvwrapper.sh`
+
+# Startup our eRegs 
+cd /vagrant
+
+# Startup regulations-core
+cd regulations-core
+workon reg-core
+nohup ./bin/django runserver 0.0.0.0:8000 &
+
+# Startup regulations-site
+cd ../regulations-site
+workon reg-site
+nohup ./bin/django runserver 0.0.0.0:8001 &
+


### PR DESCRIPTION
This PR updates regulations-bootstrap for CFPB use, adds some additional nicety to the Vagrant setup (automatically runs the `reg_bootstrap.sh` and adds a `startup.sh` to start the reg-core and reg-site services).
## Additions
- `startup.sh` to start regulations-core and regulations-site when the virtual machine starts. 
## Changes
- Changed `regs_bootstrap.sh` for the CFPB
- Changed `bootstrap.sh` to run `regs_bootstrap.sh` during provisioning.
- Changed the assumption above where the regulations repository checkouts will be stored. `bootstrap.sh` will run `regs_bootstrap.sh` on the `/vagrant` directory so that the checkouts will be accessible from the host system.
- Changed `README.md` to include more detail and more CFPB-specificity.
## Review
- @ascott1 
- @grapesmoker 
