### PR TITLE
Include regulations-stub, node, and build the regulations-site front-end

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 regulations-core/
 regulations-parser/
 regulations-site/
+regulations-stub/
 fr-notices/
 .DS_Store
 .DS_Store?

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -11,13 +11,19 @@ apt-get install libxml2-dev libxslt1-dev zlib1g-dev -y
 pip install virtualenv
 pip install virtualenvwrapper
 
+# Fetch a more recent nodejs than what's available from apt
+mkdir /opt/nodejs && cd /opt/nodejs && curl -L -s http://nodejs.org/dist/v0.12.2/node-v0.12.2-linux-x64.tar.gz | tar --strip-components 1 -xz
+# Install Node dependencies
+/opt/nodejs/bin/npm install -g grunt-cli bower browserify 
+
 # Setup eRegs environment
 sudo su vagrant <<'EOF'
 mkdir ~/.virtualenvs
+echo "export PATH=/opt/nodejs/bin:$PATH" >> ~/.bashrc
 echo "export WORKON_HOME=~/.virtualenvs" >> ~/.bashrc
 echo "export VIRTUALENVWRAPPER_VIRTUALENV=/usr/local/bin/virtualenv" >> ~/.bashrc
 echo "source /usr/local/bin/virtualenvwrapper.sh" >> ~/.bashrc
 source ~/.bashrc
 source /usr/local/bin/virtualenvwrapper.sh
-cd /vagrant && ./regs_bootstrap.sh
+cd /vagrant && bash -l regs_bootstrap.sh
 EOF

--- a/regs_bootstrap.sh
+++ b/regs_bootstrap.sh
@@ -1,7 +1,8 @@
-#!/usr/bin/env bash
+#!/usr/bin/env bash -l
 
 # Clone the relevent repos
 git clone https://github.com/cfpb/regulations-parser
+git clone https://github.com/cfpb/regulations-stub
 git clone https://github.com/cfpb/regulations-core
 git clone https://github.com/cfpb/regulations-site
 git clone https://github.com/cfpb/fr-notices.git
@@ -9,6 +10,7 @@ git clone https://github.com/cfpb/fr-notices.git
 # Make virtualenvs for each component.
 source `which virtualenvwrapper.sh`
 mkvirtualenv reg-parser
+mkvirtualenv reg-stub
 mkvirtualenv reg-core
 mkvirtualenv reg-site
 
@@ -17,7 +19,19 @@ cd regulations-parser
 workon reg-parser
 pip install -r requirements.txt
 pip install -r requirements_test.txt
-echo 'API_BASE = "http://localhost:8000/"' >> local_settings.py
+cat << 'EOF' >> local_settings.py
+# Uncoment the following line to write directly to regulations-core
+API_BASE = "http://localhost:8000/"
+
+# Uncoment the following line to write to the regulations-stub stub 
+# folder instead
+# OUTPUT_DIR="../regulations-stub/stub/"
+EOF
+
+# Setup the stub folder
+cd ../regulations-stub
+workon reg-stub
+pip install -r requirements.txt
 
 # Setup the API
 cd ../regulations-core
@@ -32,6 +46,7 @@ cd ../regulations-site
 workon reg-site
 pip install zc.buildout
 buildout
+sh ./frontendbuild.sh
 cp regulations/settings/base.py regulations/settings/local_settings.py
 sed -i -e 's|^DEBUG = False|DEBUG = True|' regulations/settings/local_settings.py
 sed -i -e "s|API_BASE = ''|API_BASE = 'http://localhost:8000/'|" regulations/settings/local_settings.py


### PR DESCRIPTION
regulations-bootstrap did not previous install node or build the regulations-site front-end. This PR fixes that. It also includes regulations-stub and settings for the parser that make it clear how to enable writing to regulations-stub as opposed to regulations-core.
