### PR TITLE
Allow bootstrapping of individual components if desired

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,28 @@ Once you have these requirements installed you can run the
 This will clone all of the eRegs repositories, make seperate virtualenvs 
 for them, and setup their dependencies.
 
+You also have the option of only bootstrapping specific components of
+eRegulations. For example:
+
+```shell
+./regs_bootstrap.sh -b core -b site
+```
+
+This will bootstrap just the API (`core`) and the site, without the
+parser. This would be useful for serving regulations that have already
+been parsed (which then just need to be added to the API).
+
+`regs_bootstrap.sh` takes the following arguments:
+
+* `-v`, verbose output. The output of all commands will be provided
+  regardless of success or failure
+* `-d`, set Django debug flags to true in regulations-core and
+  regulations-site.
+* `-c [URL]`, API url to configure for regulations-parser and
+  regulations-site
+* `-b [...]` component to bootstrap, either `parser`, `core`, or `site`.
+  This can be provided up to three times.
+
 ## Bootstrap with Vagrant
 
 To bootstrap eRegs in a [Vagrant](https://www.vagrantup.com/) virtual 

--- a/regs_bootstrap.sh
+++ b/regs_bootstrap.sh
@@ -162,10 +162,10 @@ bootstrap_site() {
 
 usage() { 
     echo "Usage: $0 [-v] [-d] [-c http://api-url] [-b component] [-b ...]" 1>&2
-    echo "      -v  verbose — outputs individual commands as they happen" 1>&2
-    echo "      -d  set Django debug flags to true" 1>&2
-    echo "      -c  API url to configure for parser and site" 1>&2
-    echo "      -b  component to bootstrap, either parser, core, or site" 1>&2
+    echo "      -v          verbose — outputs individual commands as they happen" 1>&2
+    echo "      -d          set Django debug flags to true" 1>&2
+    echo "      -c [URL]    API url to configure for parser and site" 1>&2
+    echo "      -b [...]    component to bootstrap, either parser, core, or site" 1>&2
     exit 1
 }
 

--- a/regs_bootstrap.sh
+++ b/regs_bootstrap.sh
@@ -1,53 +1,239 @@
 #!/usr/bin/env bash -l
 
-# Clone the relevent repos
-git clone https://github.com/cfpb/regulations-parser
-git clone https://github.com/cfpb/regulations-stub
-git clone https://github.com/cfpb/regulations-core
-git clone https://github.com/cfpb/regulations-site
-git clone https://github.com/cfpb/fr-notices.git
+COMPONENTS=""
+API_BASE="http://localhost:8000"
+DEBUG=false
+VERBOSE=false
+SETUP_ERRORS=false
 
-# Make virtualenvs for each component.
 source `which virtualenvwrapper.sh`
-mkvirtualenv reg-parser
-mkvirtualenv reg-stub
-mkvirtualenv reg-core
-mkvirtualenv reg-site
 
-# Setup the parser
-cd regulations-parser
-workon reg-parser
-pip install -r requirements.txt
-pip install -r requirements_test.txt
-cat << 'EOF' >> local_settings.py
+try_to() {
+    # Try to perform a command, wrapped in nice messages and
+    # error/verbose handling.
+    message=$1
+    command=$2
+    echo -n "`tput setaf 2; tput bold`$message... `tput sgr0`"
+
+    if $VERBOSE; then
+        echo ""
+        $command
+    elif ! output=$($command 2>&1); then
+        echo "`tput setaf 1; tput bold`error`tput sgr0`"
+        echo "$output"
+        return 1
+    else
+        echo "`tput bold`done`tput sgr0`"
+    fi
+}
+
+## Parser
+
+clone_parser() {
+    # For the parser clone regulations-parser, regulations-sub, and
+    # fr-notices so that the JSON and XML are both also available.
+    git clone https://github.com/cfpb/regulations-parser
+    git clone https://github.com/cfpb/regulations-stub
+    git clone https://github.com/cfpb/fr-notices.git
+}
+
+make_parser_virtualenv() {
+    # Make the virtualenvs
+    mkvirtualenv reg-parser
+    mkvirtualenv reg-stub
+}
+
+setup_parser() {
+    # Setup the parser
+    cd regulations-parser
+    workon reg-parser
+    pip install -r requirements.txt
+    pip install -r requirements_test.txt
+    cat << 'EOF' >> local_settings.py
 # Uncoment the following line to write directly to regulations-core
-API_BASE = "http://localhost:8000/"
+API_BASE = "$API_BASE"
 
 # Uncoment the following line to write to the regulations-stub stub 
 # folder instead
 # OUTPUT_DIR="../regulations-stub/stub/"
+
+LOCAL_XML_PATHS = ['../fr-notices/']
 EOF
 
-# Setup the stub folder
-cd ../regulations-stub
-workon reg-stub
-pip install -r requirements.txt
+    # Setup the stub folder
+    cd ../regulations-stub
+    workon reg-stub
+    pip install -r requirements.txt
+    cd ..
+}
 
-# Setup the API
-cd ../regulations-core
-workon reg-core
-pip install zc.buildout
-buildout
-./bin/django syncdb
-./bin/django migrate
+bootstrap_parser() {
+    # Bootstrap the parser. 
+    if [[ $COMPONENTS != *"parser"* ]]; then
+        exit
+    fi
 
-# Setup the front-end site
-cd ../regulations-site
-workon reg-site
-pip install zc.buildout
-buildout
-sh ./frontendbuild.sh
-cp regulations/settings/base.py regulations/settings/local_settings.py
-sed -i -e 's|^DEBUG = False|DEBUG = True|' regulations/settings/local_settings.py
-sed -i -e "s|API_BASE = ''|API_BASE = 'http://localhost:8000/'|" regulations/settings/local_settings.py
+    try_to 'cloning parser repositories' clone_parser
+    try_to 'making parser virtualenvs' make_parser_virtualenv
+    try_to 'setting up parser' setup_parser
 
+    if [ $? -ne 0 ]; then
+        SETUP_ERRORS=true
+    fi
+}
+
+## Core, API
+
+clone_core() {
+    git clone https://github.com/cfpb/regulations-core
+}
+
+make_core_virtualenv() {
+    mkvirtualenv reg-core
+}
+    
+setup_core() {
+    # Setup the API
+    cd regulations-core
+    workon reg-core
+    pip install zc.buildout
+    buildout
+    ./bin/django syncdb
+    ./bin/django migrate
+    cd ..
+}
+
+bootstrap_core() {
+    # Bootstrap the api
+    if [[ $COMPONENTS != *"core"* ]]; then
+        exit
+    fi
+
+    try_to 'cloning core repository' clone_core
+    try_to 'making core virtualenv' make_core_virtualenv
+    try_to 'setting up core' setup_core
+
+    if [ $? -ne 0 ]; then
+        SETUP_ERRORS=true
+    fi
+}
+
+## Site
+
+clone_site() {
+    git clone https://github.com/cfpb/regulations-site
+}
+
+make_site_virtualenv() {
+    mkvirtualenv reg-site
+}
+
+setup_site() {
+    # Setup the front-end site
+    cd regulations-site
+    workon reg-site
+    pip install zc.buildout
+    buildout
+    sh ./frontendbuild.sh
+    cp regulations/settings/base.py regulations/settings/local_settings.py
+    if $DEBUG; then
+        sed -i -e 's|^DEBUG = False|DEBUG = True|' regulations/settings/local_settings.py
+    fi
+    sed -i -e "s|API_BASE = ''|API_BASE = '$API_BASE'|" regulations/settings/local_settings.py
+    cd ..
+}
+
+bootstrap_site() {
+    # Bootstrap the site
+    if [[ $COMPONENTS != *"site"* ]]; then
+        exit
+    fi
+
+    try_to 'cloning site repository' clone_site
+    try_to 'making site virtualenv' make_site_virtualenv
+    try_to 'setting up site' setup_site
+
+    if [ $? -ne 0 ]; then
+        SETUP_ERRORS=true
+    fi
+}
+
+## Usage
+
+usage() { 
+    echo "Usage: $0 [-v] [-d] [-c http://api-url] [-b component] [-b ...]" 1>&2
+    echo "      -v  verbose — outputs individual commands as they happen" 1>&2
+    echo "      -d  set Django debug flags to true" 1>&2
+    echo "      -c  API url to configure for parser and site" 1>&2
+    echo "      -b  component to bootstrap, either parser, core, or site" 1>&2
+    exit 1
+}
+
+while getopts ":b:c:d:vh" OPT; do
+    case $OPT in
+        b)
+            COMPONENTS="$COMPONENTS $OPTARG"
+            ;;
+        c)
+            API_BASE=$OPTARG
+            ;;
+        d)
+            DEBUG=true
+            ;;
+        v)
+            VERBOSE=true
+            ;;
+        h)
+            usage
+            ;;
+        \?)
+            echo "Invalid option: -$OPTARG" >&2
+            usage
+            ;;
+    esac
+done
+
+# If we didn't get any components, enable all of them
+if [ -z "$COMPONENTS" ]; then
+    COMPONENTS="parser core site"
+fi
+
+# Perform the bootstrap process
+
+bootstrap_parser
+bootstrap_core
+bootstrap_site
+
+if $SETUP_ERRORS; then
+    exit 1
+fi
+
+# If we're running interactively then provide a bit of help getting started
+if [ -z $PS1 ]; then
+    echo "`tput bold`Bootstrap completed.`tput sgr0`"
+    echo 
+
+    if [[ $COMPONENTS == *"parser"* ]]; then
+        echo "`tput bold`To use the parser:`tput sgr0`"
+        echo "    $ cd regulations-parser"
+        echo "    $ workon reg-parser"
+        echo "    $ ./build_from.py [XML FILE] [TITLE] [ACT TITLE] [ACT SECTION]"
+        echo "Please see the parser documentation for more information."
+        echo 
+    fi
+    if [[ $COMPONENTS == *"core"* ]]; then
+        echo "`tput bold`To use the API:`tput sgr0`"
+        echo "    $ cd regulations-core"
+        echo "    $ workon reg-core"
+        echo "    $ ./bin/django runserver 0.0.0.0:8000"
+        echo 
+        
+    fi
+    if [[ $COMPONENTS == *"site"* ]]; then
+        echo "`tput bold`To use the site:`tput sgr0`"
+        echo "    $ cd regulations-site"
+        echo "    $ workon reg-site"
+        echo "    $ ./bin/django runserver 0.0.0.0:8001"
+        echo 
+    fi
+fi

--- a/regs_bootstrap.sh
+++ b/regs_bootstrap.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash -l
+#!/usr/bin/env bash
 
 COMPONENTS=""
 API_BASE="http://localhost:8000"


### PR DESCRIPTION
This PR makes some substantial modifications to the `regs_bootstrap.sh` script to provide a bit more control over its results. 
- It's now possible to bootstrap individual components 
- Output from each stage is captured and echoed if `-v` is given or there's an error
- Some very brief "getting started" info is provided at the end of the process if all went well.

This also means that now there's usage information! Running `./regs_bootstrap.sh` will have the same result as before, however, there are now a series of options:
- `-v`, verbose output. The output of all commands will be provided regardless of success or failure
- `-d`, set Django debug flags to true in regulations-core and regulations-site.
- `-c [URL]`, API url to configure for regulations-parser and regulations-site
- `-b [...]` component to bootstrap, either `parser`, `core`, or `site`. This can be provided up to three times.

For example:

``` shell
./regs_bootstrap.sh -b core -b site
```

Will bootstrap just regulations-core and regulations-site.

This also provides some handy "getting started" information at the end:

<img width="488" alt="bootstrap" src="https://cloud.githubusercontent.com/assets/10562538/8549436/b8d291f8-2498-11e5-8a6c-4fbb81600740.png">
